### PR TITLE
Fix Traefik routing to include a redirect for trailing slash

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -340,7 +340,11 @@ services:
       - 'traefik.http.routers.rss_bridge.rule=PathPrefix(`/${API_VERSION}/rss-bridge`)'
       # Specify the RSS-Bridge service port
       - 'traefik.http.services.rss_bridge.loadbalancer.server.port=80'
-      # Add middleware to this route to strip the /v1/rss-bridge prefix
-      - 'traefik.http.middlewares.strip_rss_bridge_prefix.stripprefix.prefixes=/${API_VERSION}/rss-bridge'
-      - 'traefik.http.middlewares.strip_rss_bridge_prefix.stripprefix.forceSlash=true'
-      - 'traefik.http.routers.rss_bridge.middlewares=strip_rss_bridge_prefix'
+      # Define redirect middleware for any requests to /v1/rss-bridge -> /v1/rss-bridge/ (trailing slash)
+      - traefik.http.middlewares.rss_bridge_redirect.redirectregex.regex=(^.*\/rss-bridge$$)
+      - traefik.http.middlewares.rss_bridge_redirect.redirectregex.replacement=$$1/
+      - traefik.http.middlewares.rss_bridge_redirect.redirectregex.permanent=true
+      # Define prefix stripping middleware for any requests to /v1/rss-bridge/*
+      - 'traefik.http.middlewares.rss_bridge_prefix.stripprefix.prefixes=/${API_VERSION}/rss-bridge'
+      # Add our middleware to the router
+      - 'traefik.http.routers.rss_bridge.middlewares=rss_bridge_redirect,rss_bridge_prefix'


### PR DESCRIPTION
You almost had this working, but it required an extra bit of middleware.  We need to force any request for `/v1/rss-bridge` to use `/v1/rss-bridge/` instead (trailing slash).

I've added a [RedirectRegex](https://doc.traefik.io/traefik/middlewares/http/redirectregex/) middleware to the router, which will intercept any request for `/v1/rss-bridge` and turn it into `/v1/rss-bridge/`.  This will mean that relative URLs like `static/style.css` will get properly resolved to http://localhost/v1/rss-bridge/static/style.css.

We should really do something similar in a few other services (status service comes to mind).  I'll file a follow-up on that.

I'm now able to do:

```
pnpm services:start rss-bridge
```

And navigate to http://localhost/v1/rss-bridge